### PR TITLE
register purroofgroup as a provider

### DIFF
--- a/pocket/provider.json
+++ b/pocket/provider.json
@@ -76,5 +76,11 @@
     "identity": "0396f3874516c5db51f1478bcf1114813ef9a6950dcc5dfa99f951342aac95eef9",
     "identityHistory": [],
     "url": "https://pocket-igniter.highstakes.ch/"
+  },
+  {
+    "name": "purroofgroup",
+    "identity": "03427a2568ce2ce0268c551c636f7afb2504ecd388fa45cb652b1350175317f459",
+    "identityHistory": [],
+    "url": "https://igniter.purroofgroup.com"
   }
 ]


### PR DESCRIPTION
Add purroofgroup as an Igniter staking provider.
- Serving arb-one, eth, eth-beacon, robinhood, hyperliquid
- Provider API: https://igniter.purroofgroup.com